### PR TITLE
fix(pr): make reviewer a different token input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   token: # change this
     required: true
     description: github token to run the action against
+  reviewerToken:
+    required: false
+    description: github token to use for the review approval
   hotfixAgainstBranch:
     required: true
     description: 1st branch (usually master\main)


### PR DESCRIPTION
since protected branches can't be reviewed by the pr author, we need an option to provide a
different token for the review user